### PR TITLE
Document refactoring strategies for trojan-go-caddy

### DIFF
--- a/plan/ansible-role-refactor.md
+++ b/plan/ansible-role-refactor.md
@@ -1,0 +1,49 @@
+# Plan: Convert `trojan-go-caddy` into an Ansible Role
+
+## Overview
+The `lightsail-proxy` project provisions Ubuntu instances and expects to bootstrap Trojan-Go and Caddy through user-data. Currently, `trojan-go-caddy` relies on ad-hoc shell scripts (`configure_trojan-go.sh`, `configure_namecheap_dns.sh`, `trojan_go_funcs.sh`) and manual steps. This plan turns the repository into a reusable Ansible role so the Terraform stack can install and maintain Trojan-Go/Caddy declaratively.
+
+## Objectives
+- Replace interactive shell scripts with idempotent Ansible tasks.
+- Expose configuration via variables matching `setup_env.yaml` expectations in `lightsail-proxy`.
+- Standardize file layout (`roles/trojan_go_caddy/{tasks,templates,files,defaults}`) for maintainability.
+- Provide local testing via Molecule to validate playbook behavior before Terraform integration.
+
+## Deliverables
+1. An Ansible role `roles/trojan_go_caddy` containing:
+   - `defaults/main.yml`: variables for domain, trojan password, Namecheap DDNS, ports, web root, etc.
+   - `tasks/main.yml`: orchestrates setup (package installation, directory creation, template rendering, service enablement).
+   - `templates/`: Jinja2 templates for `Caddyfile`, `trojan-go.json`, and placeholder HTML content.
+   - `handlers/main.yml`: reloads Caddy and restarts Trojan-Go when configurations change.
+2. Top-level playbook `playbooks/provision.yml` that invokes the role using variables provided by `setup_env.yaml`.
+3. `molecule/default/` scenario with converge/verify steps using Docker or Vagrant to ensure idempotence.
+4. Documentation updates explaining how `lightsail-proxy` should call the role.
+
+## Implementation Steps
+1. **Repository Restructure**
+   - Create `ansible.cfg`, `collections/requirements.yml` (pin `community.docker`), and `requirements.txt` for Molecule.
+   - Move shell helper scripts into an `archive/` folder for reference and note their deprecated status.
+2. **Role Authoring**
+   - Write tasks to install required packages (`docker`, `docker-compose`, `uuid-runtime`, etc.).
+   - Manage directories `/opt/trojan-go`, `/opt/caddy`, `/var/www/trojan`, and log files with correct permissions.
+   - Render configuration templates using Ansible variables. Leverage `template` module for `Caddyfile` and `trojan-go` config aligning with current script output.
+   - Use `community.docker.docker_compose` module to deploy the stack from a managed compose file instead of manually running `docker-compose`.
+3. **Service Management**
+   - Introduce a systemd unit or rely on Docker Compose managed via `docker stack`. Ensure idempotent start/enable.
+   - Register handlers for configuration changes to trigger container recreation or reload commands.
+4. **Testing Setup**
+   - Configure Molecule with Docker driver (e.g., Ubuntu 22.04 image).
+   - Implement `molecule.yml`, `converge.yml` calling the role, and `verify.yml` (Ansible or Testinfra) to assert files/ports exist.
+   - Add GitHub Actions workflow `ci.yml` running Molecule tests.
+5. **Documentation & Integration**
+   - Update `README.md` with instructions for running the playbook locally and from `lightsail-proxy`.
+   - Modify `lightsail-proxy/setup_env.yaml` (in its repository) to consume the new role (future work). Document required variable mappings and example inventory snippet.
+
+## Risks & Mitigations
+- **Terraform user-data size**: Large playbooks may slow boot. Mitigate by packaging role as tarball fetched via `ansible-pull` or using prebuilt release archive.
+- **Molecule resource usage**: Keep scenario lean (disable heavy dependencies) and provide skip instructions for constrained environments.
+
+## Next Steps
+- Approve role-based direction.
+- Begin restructuring repository and authoring tasks/templates.
+- Coordinate with `lightsail-proxy` maintainers to align variable names and integration timeline.

--- a/plan/docker-compose-modernization.md
+++ b/plan/docker-compose-modernization.md
@@ -1,0 +1,54 @@
+# Plan: Standardize Docker Deployment with Compose v2 and GitOps Workflow
+
+## Overview
+The repository currently stores Docker Compose and helper scripts without lifecycle management. Configuration drift occurs because files are generated manually. This plan restructures the project into a declarative Docker Compose stack with versioned configuration, automated TLS provisioning, and GitOps-style deployment pipeline.
+
+## Objectives
+- Maintain canonical Compose manifests committed to the repo instead of generated via shell scripts.
+- Parameterize environment via `.env` and templated overrides for domain-specific values.
+- Integrate automated provisioning (Let's Encrypt via Caddy, cron jobs for renewal) with minimal manual input.
+- Enable remote updates by syncing the repository and running a single make/compose command.
+
+## Deliverables
+1. `docker/` directory containing:
+   - `compose.yml` (Compose v2 syntax) defining services: `caddy`, `trojan-go`, optional `watchtower` for updates.
+   - `config/` with templated `Caddyfile.j2`, `trojan-go.json.j2`, `env.example`.
+   - `scripts/` directory with non-interactive helpers (e.g., `render-config.py` or `gomplate` templates).
+2. `Makefile` exposing targets (`make render`, `make up`, `make down`, `make logs`).
+3. GitHub Actions workflow to lint Compose (`docker compose config`), run Hadolint on Dockerfiles if added, and validate templates.
+4. Documentation describing GitOps deployment: clone repo onto host, populate `.env`, run `make deploy`.
+
+## Implementation Steps
+1. **Compose Refactor**
+   - Rewrite `docker-compose_trojan-go.yml` using Compose specification v3.9 features (profiles, secrets, healthchecks).
+   - Use named volumes for `caddy_data`, `caddy_config`, and `trojan_data` to keep TLS certificates persistent.
+   - Define networks for isolation between Caddy and Trojan-Go containers.
+2. **Configuration Management**
+   - Replace shell-based template generation with Jinja2/Envsubst pipeline (`scripts/render.py`).
+   - Accept inputs from `.env` (DOMAIN, TROJAN_PASSWORD, EMAIL) and produce configs under `rendered/` tracked via `.gitignore`.
+   - Provide default HTML assets under `assets/` copied during render.
+3. **Automation & Idempotence**
+   - Introduce `make` targets that call `docker compose` with environment variable file and ensure correct exit codes.
+   - Optionally add a systemd unit template to run `docker compose up` as a service (commit to `systemd/`).
+4. **Secrets Handling**
+   - Use `.env` for non-sensitive defaults and reference Docker secrets or external files for passwords.
+   - Document process for injecting secrets via Terraform/Ansible.
+5. **GitOps Deployment Flow**
+   - Document steps for host provisioning: install Docker, clone repo, copy `.env`, run `make deploy`.
+   - Add guidance for hooking into `lightsail-proxy` user-data: git clone repo on boot, run render/deploy commands automatically.
+6. **Testing**
+   - Add local test harness script or `act` workflow verifying Compose syntax and config rendering.
+   - Provide integration test instructions (e.g., `docker compose up -d` on GitHub Codespaces using ephemeral domain + TLS skip).
+
+## Integration Considerations
+- Terraform user-data can clone a specific tag/release and run `make render deploy` using exported environment variables.
+- Ansible role (from other plan) can include this stack as a dependency by invoking Make targets or Compose modules.
+
+## Risks & Mitigations
+- **Template complexity**: Keep templates simple, rely on environment substitution and defaults to reduce branching.
+- **Secrets in `.env`**: Provide `.env.template` and recommend secret managers or Terraform locals for sensitive values.
+
+## Next Steps
+- Approve Compose-first direction.
+- Begin restructure by committing canonical Compose + templates.
+- Align with Terraform/Ansible integration strategies for automated deployment.

--- a/plan/python-cli-refactor.md
+++ b/plan/python-cli-refactor.md
@@ -1,0 +1,58 @@
+# Plan: Replace Shell Scripts with a Python CLI & Configuration Templates
+
+## Overview
+Current automation lives in multiple interactive bash scripts that generate configs and rely on `source` side-effects. This plan consolidates the logic into a Python CLI package with declarative templates. The CLI can be consumed locally or by Terraform/Ansible user-data, reducing shell complexity while remaining lightweight.
+
+## Objectives
+- Provide a single entrypoint (`python -m trojan_go_caddy configure`) to scaffold all required assets.
+- Use type-safe configuration (`pydantic` or `dataclasses`) that can ingest environment variables, `.env` files, or YAML.
+- Offer subcommands for DNS updates, Docker Compose management, and validation.
+- Preserve compatibility with existing directories (`caddy/`, `trojan-go/`, `wwwroot/`) but make paths configurable.
+
+## Deliverables
+1. Python package `trojan_go_caddy/` with modules:
+   - `config.py`: configuration models & loaders (env vars, CLI flags, YAML input).
+   - `templates/`: Jinja2 templates for Caddyfile, Trojan-Go config, and sample HTML.
+   - `dns.py`: Namecheap Dynamic DNS updater using `requests` with retry/backoff.
+   - `cli.py`: Click/Typer CLI exposing commands (`configure`, `dns-update`, `docker up/down`, `validate`).
+2. `pyproject.toml` using Poetry or Hatch for dependency management and packaging.
+3. Unit tests validating template rendering, CLI parsing, and DNS client behavior.
+4. GitHub Actions workflow for linting (`ruff`), type-checking (`pyright`), and tests (`pytest`).
+
+## Implementation Steps
+1. **Bootstrap Package**
+   - Initialize `pyproject.toml` with dependencies (`typer`, `pydantic`, `jinja2`, `requests`, `pyyaml`).
+   - Set up `src/` layout and enable `ruff` + `pyright` config files.
+2. **Implement Configuration Loader**
+   - Create data models for domain settings, TLS paths, Docker Compose options.
+   - Add `from_env`, `from_file`, and CLI argument parsing to build configuration.
+   - Support automatic UUID generation when password not provided.
+3. **Template Rendering**
+   - Translate existing shell `cat <<EOF` templates into `.j2` files.
+   - Provide CLI `configure` command that writes rendered files to target directories, ensuring directories exist.
+4. **DNS Update Command**
+   - Implement HTTP call to Namecheap endpoint with structured response handling and logging.
+   - Add `--dry-run` support to preview requests without executing.
+5. **Docker Helpers**
+   - Provide wrappers around `subprocess` or Docker SDK to run `docker compose` commands with sanitized environment.
+   - Optionally generate Compose file from template to keep configuration centralized.
+6. **Testing & CI**
+   - Write pytest suites for config parsing, template output snapshots, and DNS URL composition.
+   - Add GitHub Actions pipeline to run lint/type/test on push and PR.
+7. **Documentation**
+   - Update README with installation instructions (`pipx install .`, `poetry run trojan-go-caddy configure --config settings.yaml`).
+   - Provide example YAML/ENV files for integration with `lightsail-proxy`.
+
+## Integration with `lightsail-proxy`
+- Package CLI as wheel/zip published to GitHub Releases or PyPI; Terraform user-data installs via `pipx`.
+- `setup_ubuntu.sh.tftpl` downloads release artifact and runs `trojan-go-caddy configure --from-env` using environment variables set by Terraform template variables.
+- DNS updates triggered through CLI invocation rather than direct `curl` commands.
+
+## Risks & Mitigations
+- **Python dependency bloat**: Keep dependency set minimal, consider optional extras for features.
+- **Runtime availability**: Ensure Python 3.10+ is available on target hosts (Ubuntu 22.04 includes it). Provide pre-flight check in CLI.
+
+## Next Steps
+- Approve Python CLI direction.
+- Scaffold package and migrate templates.
+- Coordinate release and update Terraform scripts to consume CLI.


### PR DESCRIPTION
## Summary
- add an Ansible role conversion plan to align the project with lightsail-proxy automation
- propose a Python CLI refactor to replace the current shell scripts with a typed toolchain
- outline a Docker Compose modernization strategy for a GitOps-friendly workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f119bfc2d88322bdf327b2e3ef019d